### PR TITLE
Fix typo: Mark the observation

### DIFF
--- a/RTMB/R/osa.R
+++ b/RTMB/R/osa.R
@@ -37,8 +37,8 @@ oneStepPredict <- function(obj,
 
 OBS_ENV <- reporter()
 
-##' @describeIn TMB-interface Mark the observation
-##' Mark observation to be used by either \code{oneStepPredict} or by \code{obj$simulate}.
+##' @describeIn TMB-interface
+##' Mark the observation to be used by either \code{oneStepPredict} or by \code{obj$simulate}.
 ##' If your objective function is using an observation \code{x}, you simply need
 ##' to run \code{x <- OBS(x)} \emph{inside the objective function}.
 ##' This will (1) allow \code{oneStepPredict} to change the class of \code{x} to

--- a/RTMB/man/TMB-interface.Rd
+++ b/RTMB/man/TMB-interface.Rd
@@ -80,8 +80,7 @@ Interface to TMB
 
 \item \code{getAll()}: Can be used to assign all parameter or data objects from a list inside the objective function.
 
-\item \code{OBS()}: Mark the observation
-Mark observation to be used by either \code{oneStepPredict} or by \code{obj$simulate}.
+\item \code{OBS()}: Mark the observation to be used by either \code{oneStepPredict} or by \code{obj$simulate}.
 If your objective function is using an observation \code{x}, you simply need
 to run \code{x <- OBS(x)} \emph{inside the objective function}.
 This will (1) allow \code{oneStepPredict} to change the class of \code{x} to


### PR DESCRIPTION
Hi! This commit fixes a small typo, where 'Mark the observation' was repeated.