### PR TITLE
Add two more PROS entries to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ PROS:
 - Debugging can be performed using the normal R debugger rather than gdb.
 - Most common TMB features are supported. See [current list of working examples](./tmb_examples).
 - Simplified interface can automatically simulate from the model and calculate OSA residuals.
+- Easy to provide multiple models in one package.
+- Easy to construct a model using functions from external packages and scripts.
 
 More information, including vignettes ([introduction](https://kaskr.r-universe.dev/RTMB/doc/RTMB-introduction.html) / [advanced](https://kaskr.r-universe.dev/RTMB/doc/RTMB-advanced.html)) and [documentation](https://kaskr.r-universe.dev/RTMB#manual), can be found on the [RTMB universe page](https://kaskr.r-universe.dev/RTMB).
 


### PR DESCRIPTION
When choosing whether to implement models in TMB or RTMB, the ease of development and maintenance are important aspects. However, there are also two important aspects that favor RTMB:
- Easy to provide multiple models in one package.
- Easy to construct a model using functions from external packages and scripts.

For example, in the [*fishgrowth*](https://cran.r-project.org/package=fishgrowth) package, I provide multiple models (vonbert, gompertz, richards, growth cessation, etc.) that would not be straightforward with a TMB package.

I'm also happy with how easy it would be to have model functions in the *fishgrowth* package call functions from other packages. That's very powerful and much easier in RTMB than in TMB.

So, I thought it might be worth adding those two entries to the README.md. Feel free to reword and improve.