### PR TITLE
chore: fixes spelling mistakes

### DIFF
--- a/RTMB/R/00roxygen.R
+++ b/RTMB/R/00roxygen.R
@@ -182,13 +182,13 @@ NULL
 ##' implementation is selected. In all other cases a default
 ##' implementation is used} (typically that of the \bold{stats}
 ##' package).
-##' Argument recycling follows the R standard (although wihout any warnings).
+##' Argument recycling follows the R standard (although without any warnings).
 ##'
 ##' Specific documentation of the functions and arguments should be looked up elsewhere:
 ##' - All S4 methods behave as the corresponding functions in the
 ##'   \bold{stats} package. However, some arguments may not be
 ##'   implemented in the AD case (e.g. \code{lower-tail}).
-##' - Other funtions behave as the corresponding TMB versions for
+##' - Other functions behave as the corresponding TMB versions for
 ##'   which documentation should be looked up online.
 ##'
 ##' @param x observation vector
@@ -347,8 +347,8 @@ NULL
 
 ## FIXME: Tidy the class union names
 ## - Given a class 'A', what's a good name for a union that can be converted to 'A' ?
-## * For example, we currently use 'ad' to denote an argument type that is convertable to 'advector'.
-## * And we use 'anysparse' to denote an argument type that is convertable to 'adsparse'.
+## * For example, we currently use 'ad' to denote an argument type that is convertible to 'advector'.
+## * And we use 'anysparse' to denote an argument type that is convertible to 'adsparse'.
 ## * We add a dot '.' to the class union to signify that it might be missing.
 ## Obviously, a bit of a mess.
 setClass("advector") ## Virtual class

--- a/RTMB/R/advector.R
+++ b/RTMB/R/advector.R
@@ -801,7 +801,7 @@ MakeADFun <- function(func, parameters, random=NULL, profile=NULL, integrate=NUL
             }
             pl <- parList(parameters, par)
             ## TMB is allowed to move data items to parameter list. We
-            ## move such parmeters to the exchange environment OBS_ENV
+            ## move such parameters to the exchange environment OBS_ENV
             ## so can be obtained by 'OBS()' rather than 'parameters':
             if (length(obj$env$data) == 0) {
                 setnm <- attr(obj$env$data, "setdata")

--- a/RTMB/R/integrate.R
+++ b/RTMB/R/integrate.R
@@ -132,7 +132,7 @@ adintegrate <- function(f, a, b, cfg) {
 ##' AD evaluation mode re-directs to a specialized RTMB implementation.
 ##' The latter imitates the R (QUADPACK) implementation by using:
 ##' - Adaptive Gauss-Kronrod (K21/G10) quadrature with fast retaping.
-##' - Wynn convergence acceleration to handle boundary singularites.
+##' - Wynn convergence acceleration to handle boundary singularities.
 ##'
 ##' Accuracy requirements are specified via relative (`rel.tol`) and absolute (`abs.tol`) tolerances.
 ##' The AD implementation tries to follow the same stopping criterion as that used by QUADPACK, which is to stop if *either* (not both!) of these tolerances are satisfied:

--- a/RTMB/R/mvgauss.R
+++ b/RTMB/R/mvgauss.R
@@ -287,7 +287,7 @@ unit <- function(x) identical(x, 1)
 
 ##' @describeIn MVgauss Helper to generate an unstructured correlation matrix to use with `dmvnorm`
 ##' @section Unstructured correlation:
-##' Replacement of `UNSTRUCTURED_CORR` functionality of TMB. Constuct object using `us <- unstructured(k)`.
+##' Replacement of `UNSTRUCTURED_CORR` functionality of TMB. Construct object using `us <- unstructured(k)`.
 ##' Now `us` has two methods: `x <- us$parms()` gives the parameter vector used as input to the objective function, and `us$corr(x)` turns the parameter vector into an unstructured correlation matrix.
 ##' @param k Dimension
 unstructured <- function(k) {

--- a/RTMB/inst/include/CallRTMB.hpp
+++ b/RTMB/inst/include/CallRTMB.hpp
@@ -43,7 +43,7 @@ void RTMB_exception_cleanup() {
 // Throw exception on illegal parallelization
 void RTMB_check_valid_parallelization() {
     if (config.nthreads > 1 && config.autopar == 0)
-      Rcpp::stop("Calling R from TMB with parallization requires 'autopar=TRUE'");
+      Rcpp::stop("Calling R from TMB with parallelization requires 'autopar=TRUE'");
 }
 
 template <class Type>

--- a/RTMB/inst/include/config.h
+++ b/RTMB/inst/include/config.h
@@ -18,7 +18,7 @@
 #define TMBAD_INDEX_TYPE uint64_t
 // Enable out-of-bounds checking
 #define TMB_SAFEBOUNDS
-// TMB FIXME: Some occurances of ASSERT and ASSERT2
+// TMB FIXME: Some occurrences of ASSERT and ASSERT2
 #undef  ASSERT
 #define ASSERT(x) TMBAD_ASSERT(x)
 #undef  ASSERT2

--- a/RTMB/inst/tinytest/test-model-spde.R
+++ b/RTMB/inst/tinytest/test-model-spde.R
@@ -63,7 +63,7 @@ f <- function(parms) {
 obj <- MakeADFun(f, parameters, silent=TRUE)
 expect_equal(f(parameters), obj$fn())
 
-## Fit model (NaNs during minimization expected - supress warnings)
+## Fit model (NaNs during minimization expected - suppress warnings)
 obj <- MakeADFun(f, parameters, random="x", silent=TRUE)
 opt <- suppressWarnings(nlminb(obj$par, obj$fn, obj$gr))
 

--- a/RTMB/man/ADintegrate.Rd
+++ b/RTMB/man/ADintegrate.Rd
@@ -51,7 +51,7 @@ AD evaluation mode re-directs to a specialized RTMB implementation.
 The latter imitates the R (QUADPACK) implementation by using:
 \itemize{
 \item Adaptive Gauss-Kronrod (K21/G10) quadrature with fast retaping.
-\item Wynn convergence acceleration to handle boundary singularites.
+\item Wynn convergence acceleration to handle boundary singularities.
 }
 
 Accuracy requirements are specified via relative (\code{rel.tol}) and absolute (\code{abs.tol}) tolerances.

--- a/RTMB/man/Distributions.Rd
+++ b/RTMB/man/Distributions.Rd
@@ -447,7 +447,7 @@ Method dispatching follows a simple rule:
 implementation is selected. In all other cases a default
 implementation is used} (typically that of the \bold{stats}
 package).
-Argument recycling follows the R standard (although wihout any warnings).
+Argument recycling follows the R standard (although without any warnings).
 }
 \details{
 Specific documentation of the functions and arguments should be looked up elsewhere:
@@ -455,7 +455,7 @@ Specific documentation of the functions and arguments should be looked up elsewh
 \item All S4 methods behave as the corresponding functions in the
 \bold{stats} package. However, some arguments may not be
 implemented in the AD case (e.g. \code{lower-tail}).
-\item Other funtions behave as the corresponding TMB versions for
+\item Other functions behave as the corresponding TMB versions for
 which documentation should be looked up online.
 }
 }

--- a/RTMB/man/MVgauss.Rd
+++ b/RTMB/man/MVgauss.Rd
@@ -77,7 +77,7 @@ In addition, \code{dmvnorm} and \code{dgmrf} can be scaled by a vector of length
 
 \section{Unstructured correlation}{
 
-Replacement of \code{UNSTRUCTURED_CORR} functionality of TMB. Constuct object using \code{us <- unstructured(k)}.
+Replacement of \code{UNSTRUCTURED_CORR} functionality of TMB. Construct object using \code{us <- unstructured(k)}.
 Now \code{us} has two methods: \code{x <- us$parms()} gives the parameter vector used as input to the objective function, and \code{us$corr(x)} turns the parameter vector into an unstructured correlation matrix.
 }
 

--- a/RTMB/src/branching.cpp
+++ b/RTMB/src/branching.cpp
@@ -78,7 +78,7 @@ struct BranchOp : global::DynamicOperator< -1, -1> {
   void forward(ForwardArgs<T> &args) { ASSERT(false); }
   void reverse(ReverseArgs<Writer> &args) { ASSERT(false); }
 
-  // Any of the two 'dtab' can be used to uniqely identify this operator.
+  // Any of the two 'dtab' can be used to uniquely identify this operator.
   // However, unlike AtomOp, we must assume that identifier is order
   // dependent (because input/output dimension doesn't necessarily
   // change for higher order JacFun() unlike WgtJacFun() ).

--- a/RTMB/src/config.h
+++ b/RTMB/src/config.h
@@ -18,7 +18,7 @@
 #define TMBAD_INDEX_TYPE uint64_t
 // Enable out-of-bounds checking
 #define TMB_SAFEBOUNDS
-// TMB FIXME: Some occurances of ASSERT and ASSERT2
+// TMB FIXME: Some occurrences of ASSERT and ASSERT2
 #undef  ASSERT
 #define ASSERT(x) TMBAD_ASSERT(x)
 #undef  ASSERT2

--- a/RTMB/src/integrate.cpp
+++ b/RTMB/src/integrate.cpp
@@ -96,7 +96,7 @@ ADrep bisect_atom(Rcpp::XPtr<TMBad::ADFun<> > adf, ADrep x_, Rcpp::List cfg) {
           return;
         }
       }
-      // Continure subdividing?
+      // Continue subdividing?
       if (el + er > tol) {
         // Subdivide largest error first
         if (el > er) {
@@ -144,7 +144,7 @@ ADrep bisect_atom(Rcpp::XPtr<TMBad::ADFun<> > adf, ADrep x_, Rcpp::List cfg) {
         fail = fail || !std::isfinite(asDouble(y[1]));
         fail = fail || !std::isfinite(asDouble(eps.back()));
         fail = fail || asDouble(y[1]) > std::abs(asDouble(y[0])) * sqrt_machine_tolerance;
-        if (fail) { // Fail => Reject extraplation
+        if (fail) { // Fail => Reject extrapolation
             // Skip this term and fall back on normal sub division for remaining terms
             subdiv(x, y, tol, left_bound, right_bound);
             // First element of eps table holds the plain sum of terms known without error

--- a/RTMB/src/misc.cpp
+++ b/RTMB/src/misc.cpp
@@ -31,7 +31,7 @@ namespace TMBad {
   Memory management:
 
   - 'Rcpp::Function' automatically PROTECTs/UNPROTECTs. This is in
-    general useful for temporary liftime objects, but we have to be
+    general useful for temporary lifetime objects, but we have to be
     careful when placing a 'Rcpp::Function' as a member of an object
     with 'unlimited lifetime' (e.g. an AD operator). If the object is
     copied (from R), it'll invoke PROTECTs that are not followed by

--- a/RTMBode/R/odesolve.R
+++ b/RTMBode/R/odesolve.R
@@ -8,7 +8,7 @@ setTape <- function(F, parms) {
     .Call(set_parms, parms)
 }
 
-## State augmentation (inital state and parameter derivatives)
+## State augmentation (initial state and parameter derivatives)
 ## DEFINITION:
 ## - The tape represents the generator, i.e. the mapping (t,y,parms) -> f(t,y)
 ## - The augmented tape must also represent the generator!

--- a/design_notes/example.R
+++ b/design_notes/example.R
@@ -117,7 +117,7 @@ MakeTape <- function(f, x, optimize=TRUE) {
 
 ## =============== Distributions
 ## Are generally not generic - must overload
-## FIXME: Dispatch must be based on all aguments x, mean, sd
+## FIXME: Dispatch must be based on all arguments x, mean, sd
 dnorm <- function(x, mean = 0, sd = 1, log = FALSE) UseMethod("dnorm", mean)
 dnorm.default <- stats::dnorm
 dnorm.advector <- function(x, mean = 0, sd = 1, log = FALSE) {

--- a/distr.R
+++ b/distr.R
@@ -137,7 +137,7 @@ getRmethod <- function(i) {
     ans <- ifelse(is.na(match(a2,a1)),"missing",a2.type)
     sig <- paste0("signature(",(paste(a2,"=",string(ans),collapse=", ")),")")
     cast <- ifelse(ans[match(a1,a2)] %in% c("ad","ad."),"advector","as.logical")
-    ## Simple case: Not stats - create new simpel function
+    ## Simple case: Not stats - create new simple function
     if (!stats) {
         def <- c(
             paste(name,"<- function(", sub("log$","log=FALSE", df$signature[i]),") {"),

--- a/rtmbTest/R/sdv_multi_compact.R
+++ b/rtmbTest/R/sdv_multi_compact.R
@@ -1,4 +1,4 @@
-## Multivatiate SV model from Table 5 of Skaug and Yu "A flexible and automated likelihood based 
+## Multivariate SV model from Table 5 of Skaug and Yu "A flexible and automated likelihood based 
 ## framework for inference in stochastic volatility models." Computational Statistics & Data Analysis 76 (2014): 642-654.
 ## Negative joint likelihood (nll) of data and parameters
 f <- function(parms) {
@@ -16,7 +16,7 @@ f <- function(parms) {
     for (j in 1:p) {
         nll <- nll - dautoreg(h[,j], phi=phi[j], scale=sigma_init[j], log=TRUE)
     }
-    ## Parameterizes correlation matrix of X in terms of Cholesky factor
+    ## Parametrizes correlation matrix of X in terms of Cholesky factor
     L <- diag(p)
     L[lower.tri(L)] <- parms$off_diag_x   
     R <- cov2cor(L%*%t(L))  # Correlation matrix of X (guarantied positive definite)

--- a/rtmbXtra/R/00roxygen.R
+++ b/rtmbXtra/R/00roxygen.R
@@ -1,6 +1,6 @@
 ##' Log space gamma function
 ##'
-##' Calculates `log(gamma(exp(x)))` with impoved stability for small x.
+##' Calculates `log(gamma(exp(x)))` with improved stability for small x.
 ##' @title Log space gamma function
 ##' @param x AD vector
 ##' @return AD vector
@@ -15,7 +15,7 @@ NULL
 
 ##' Logit transformed inverse cloglog
 ##'
-##' Calculates `log(gamma(exp(x)))` with impoved stability for small x.
+##' Calculates `log(gamma(exp(x)))` with improved stability for small x.
 ##' @title Logit transformed inverse cloglog
 ##' @param x AD vector
 ##' @return AD vector
@@ -26,7 +26,7 @@ NULL
 
 ##' Logit transformed pnorm
 ##'
-##' Calculates `qlogis(pnorm(x)))` with impoved accuracy for small and large x.
+##' Calculates `qlogis(pnorm(x)))` with improved accuracy for small and large x.
 ##' @title Logit transformed pnorm
 ##' @param x AD vector
 ##' @return AD vector

--- a/tmb_examples/hmm.R
+++ b/tmb_examples/hmm.R
@@ -52,7 +52,7 @@ sde <- function(lambda, gamma, sigmaX) {
     list(advection  = function (x) lambda * x - gamma * x^3,
          dispersion = function (x) x*0 + sigmaX )
 }
-## Finite volume discritize advection diffusion equation. Assuming
+## Finite volume discretize advection diffusion equation. Assuming
 ## equidistant grid and using central difference scheme for advection.
 fvade <- function(sde, grid) {
     h <- diff(grid)[1]
@@ -116,7 +116,7 @@ func <- function(parameters) {
     sigmaY <- exp(logsY)
     ## Construct the SDE
     sde_object <- sde(lambda, gamma, sigmaX)
-    ## Finite volume disretize and report generator
+    ## Finite volume discretize and report generator
     fvol <- fvade(sde_object, grid)
     REPORT(fvol$A)
     ## Construct likelihood function

--- a/tmb_examples/sdv_multi.R
+++ b/tmb_examples/sdv_multi.R
@@ -1,4 +1,4 @@
-# Multivatiate SV model from Table 5 of Skaug and Yu "A flexible and automated likelihood based 
+# Multivariate SV model from Table 5 of Skaug and Yu "A flexible and automated likelihood based 
 # framework for inference in stochastic volatility models." Computational Statistics & Data Analysis 76 (2014): 642-654.
 
 library(RTMB)
@@ -35,7 +35,7 @@ f <- function(parms) {
   for(j in 1:p) 
     nll <- nll - sum(dnorm(h[-1,j],phi[j]*h[-n,j],sigma[j],log=TRUE))  # AR(1) process
 
-  # Parameterizes correlation matrix of X in terms of Cholesky factor
+  # Parametrizes correlation matrix of X in terms of Cholesky factor
   L <- diag(p)
   L[lower.tri(L)] <- parms$off_diag_x   
   row_norms <- apply(L, 1, function(row) sqrt(sum(row^2)))

--- a/tmb_examples/sdv_multi_compact.R
+++ b/tmb_examples/sdv_multi_compact.R
@@ -1,4 +1,4 @@
-## Multivatiate SV model from Table 5 of Skaug and Yu "A flexible and automated likelihood based 
+## Multivariate SV model from Table 5 of Skaug and Yu "A flexible and automated likelihood based 
 ## framework for inference in stochastic volatility models." Computational Statistics & Data Analysis 76 (2014): 642-654.
 
 library(RTMB)
@@ -34,7 +34,7 @@ f <- function(parms) {
     for (j in 1:p) {
         nll <- nll - dautoreg(h[,j], phi=phi[j], scale=sigma_init[j], log=TRUE)
     }
-    ## Parameterizes correlation matrix of X in terms of Cholesky factor
+    ## Parametrizes correlation matrix of X in terms of Cholesky factor
     R <- us$corr(off_diag_x)
     ## Scaling parameter
     mux <- matrix(mu_x, nrow(h), ncol(h), byrow=TRUE)

--- a/tmb_examples/spde.R
+++ b/tmb_examples/spde.R
@@ -24,7 +24,7 @@ mesh <- fmesher::fm_mesh_2d(
 
 plot(mesh)
 
-spde <- fmesher::fm_fem(mesh) # Calculate the sparse matrices c0,g1, g2 need for precission matrix
+spde <- fmesher::fm_fem(mesh) # Calculate the sparse matrices c0,g1, g2 need for precision matrix
 
 ## Fixed effects part of model
 X <- model.matrix( ~ 1 + sex + age + wbc + tpi, data = LeukSurv)


### PR DESCRIPTION
While developing NOAA-FIMS/FIMS we noticed that there is a spelling mistake in RTMB/inst/include/config.h so I decided to check the entire RTMB repository for spelling using `cspell "**/*.{cpp,hpp,h,R,Rmd,md}`. I then noticed the following words that were misspelled and fixed them. I also reran the R documentation to update the .Rd files. I am happy to make any changes that you need to this branch, just let me know.

parallization
aguments
simpel
occurances
supress
wihout
funtions
convertable
singularites
Constuct
uniqely
Continure
extraplation
liftime
inital
Multivatiate
Parameterizes
impoved
discritize
disretize
precission